### PR TITLE
Generalize generators from NonEmpty to Foldable1

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,11 +16,12 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-nonempty": "^4.0.0",
     "purescript-tailrec": "^3.0.0",
     "purescript-tuples": "^4.0.0",
     "purescript-unfoldable": "^3.0.0",
-    "purescript-integers": "^3.0.0"
+    "purescript-integers": "^3.0.0",
+    "purescript-foldable-traversable": "^3.3.0",
+    "purescript-nonempty": "^4.2.0"
   },
   "devDependencies": {
     "purescript-console": "^3.0.0",


### PR DESCRIPTION
This depends on merging of this PR https://github.com/purescript/purescript-nonempty/pull/27

It is technically breaking, as it adds a higher bound for `purescript-foldable-traversable`.