### PR TITLE
Fix 'fromIndex' internal helper

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   },
   "devDependencies": {
     "eslint": "^4.19.1",
-    "pulp": "^12.2.0",
-    "purescript-psa": "^0.6.0",
+    "pulp": "^15.0.0",
+    "purescript-psa": "^0.7.3",
     "rimraf": "^2.6.2"
   }
 }

--- a/src/Control/Monad/Gen.purs
+++ b/src/Control/Monad/Gen.purs
@@ -125,6 +125,8 @@ filtered gen = tailRecM go unit
 fromIndex :: forall f a. Foldable1 f => Int -> f a -> a
 fromIndex i xs = go i (foldr Cons Nil xs)
   where
+    go _ (Cons a Nil) = a
     go j (Cons a _) | j <= 0 = a
     go j (Cons _ as) = go (j - 1) as
-    go _ Nil = un Last (foldMap1 Last xs)
+    -- next case is "impossible", but serves as proof of non-emptyness
+    go _ Nil = un Last (foldMap1 Last xs) 

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -31,6 +31,13 @@ main = do
     log "`genNonEmpty` should not reduce the remainder size below zero"
     one :: NonEmpty Array Int ← Gen.resize (const 0) $ GenC.genNonEmpty (Gen.sized pure)
     liftEffect $ assertEqual { actual: one, expected: 0 :| [] }
+    
+    log "Ensure that `elements` will produce all possible values (tests will hang if this fails)"
+    _ ← Gen.suchThat (Gen.elements ("A" :| ["B", "C", "D"])) (_ == "A")
+    _ ← Gen.suchThat (Gen.elements ("A" :| ["B", "C", "D"])) (_ == "B")
+    _ ← Gen.suchThat (Gen.elements ("A" :| ["B", "C", "D"])) (_ == "C")
+    _ ← Gen.suchThat (Gen.elements ("A" :| ["B", "C", "D"])) (_ == "D")
+    pure unit
 
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
Resolves #22 

The test isn't great, since it'll just never complete if it fails, but that's better than nothing for now. Testing the distribution properly would be good at some point, seems like we did have more tests at one point: #16.

`fromIndex` could be expensive if it used with an index greater than the size of the `Foldable1` since it uses `Last` after already having converted to a linked list and running through it... but I'm pretty sure it won't hit that case the way it's used anyway.