### PR TITLE
Make `elements` test no longer hang at cost of possible false negative

### DIFF
--- a/test/Main.purs
+++ b/test/Main.purs
@@ -37,6 +37,9 @@ main = do
 
     log "Ensure that `elements` will produce all possible values (low chance of false negative)"
     let testElems = "A" :| ["B", "C", "D"]
+
+    -- use `resize` to generate an Array of 1,000 elements
+    -- to reduce the chance of a false positive.
     elems :: Array String <- Gen.resize (\_ -> 1000) (Gen.unfoldable (Gen.elements testElems))
 
     let

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -45,8 +45,7 @@ main = do
     let
       -- implement a Set-like value without depending on ordered-collections
       -- because that library depends on this one.
-      addElemIfNew arr e = if Array.elem e arr then arr else Array.snoc arr e
-      actualElems = Array.sort $ foldl addElemIfNew [] elems
+      actualElems = Array.sort $ Array.nub elems
       expectedElems = foldl Array.snoc [] testElems
 
     liftEffect $ assertEqual { actual: actualElems, expected: expectedElems }


### PR DESCRIPTION
See [this conversation](https://github.com/purescript/purescript-gen/pull/23#discussion_r523308872) for context.